### PR TITLE
Skk formatting changes

### DIFF
--- a/thermoplotting/energy.py
+++ b/thermoplotting/energy.py
@@ -243,7 +243,9 @@ class Energy3(object):
         """
         ax = scatter3(ax, self._running_data[self._xlabel],
                       self._running_data[self._ylabel],
-                      self._running_data[self._zlabel])
+                      self._running_data[self._zlabel],
+                      *args,
+                      **kwargs)
         return ax
 
     def projected_scatter(self, ax, *args, **kwargs):
@@ -258,7 +260,9 @@ class Energy3(object):
         """
         ax = projected_scatter(ax, self._running_data[self._xlabel],
                                self._running_data[self._ylabel],
-                               self._running_data[self._zlabel])
+                               self._running_data[self._zlabel],
+                               *args,
+                               **kwargs)
         return ax
 
     def draw_convex_hull(self, ax):

--- a/thermoplotting/energy.py
+++ b/thermoplotting/energy.py
@@ -207,7 +207,7 @@ def hull_points(x, y, z):
             hull_points.append(tuple(point))
     hull_points=set(hull_points)
     for i,pt in enumerate(hull_points):
-        hull_points[i]=numpy.array(pt)
+        hull_points[i]=np.array(pt)
     return hull_points
 
 

--- a/thermoplotting/energy.py
+++ b/thermoplotting/energy.py
@@ -186,6 +186,28 @@ def scatter_projected_convex_hull(ax, x, y, z, **kwargs):
     #Set projected view? axis, aspect, etc?
     return ax
 
+def hull_points(x, y, z):
+    """Return the points that make up the convex hull
+    Parameters
+    ----------
+    x : composition data
+    y : composition data
+    z : energy data
+
+    Returns
+    -------
+    list of points
+
+    """
+    digested = _digest_data(x, y, z)
+    facets = ternary.pruned_hull_facets(digested)
+    hull_points=[]
+    for f in facets:
+        for point in f:
+            hull_points.append(point)
+    hull_points=list(set(hull_points))
+    return hull_points
+
 
 class Energy3(object):
     """Handles plotting ternary energy, with
@@ -322,6 +344,11 @@ class Energy3(object):
 
         ax.set_aspect('equal')
         return ax
+
+    def hull_points(self):
+        return hull_points(self._running_data[self._xlabel],
+                            self._running_data[self._ylabel],
+                            self._running_data[self._zlabel])
 
 
 class Energy2(object):

--- a/thermoplotting/energy.py
+++ b/thermoplotting/energy.py
@@ -260,7 +260,6 @@ class Energy3(object):
         """
         ax = projected_scatter(ax, self._running_data[self._xlabel],
                                self._running_data[self._ylabel],
-                               self._running_data[self._zlabel],
                                *args,
                                **kwargs)
         return ax

--- a/thermoplotting/energy.py
+++ b/thermoplotting/energy.py
@@ -205,7 +205,7 @@ def hull_points(x, y, z):
     for f in facets:
         for point in f:
             hull_points.append(tuple(point))
-    hull_points=set(hull_points)
+    hull_points=list(set(hull_points))
     for i,pt in enumerate(hull_points):
         hull_points[i]=np.array(pt)
     return hull_points

--- a/thermoplotting/energy.py
+++ b/thermoplotting/energy.py
@@ -160,7 +160,7 @@ def draw_projected_convex_hull(ax,
 
     return ax
 
-def scatter_projected_convex_hull(ax, x, y, z, **kwargs):
+def scatter_projected_convex_hull(ax, x, y, z, kwargs):
     """Draw the points that make up the convex hull, but plot
     them projected onto the composition plane   
 
@@ -181,7 +181,7 @@ def scatter_projected_convex_hull(ax, x, y, z, **kwargs):
     facets = ternary.pruned_hull_facets(digested)
 
     for f in facets:
-        ax = _scatter_projected_facet(ax, f, **kwargs)
+        ax = _scatter_projected_facet(ax, f, kwargs)
 
     #Set projected view? axis, aspect, etc?
     return ax
@@ -300,7 +300,7 @@ class Energy3(object):
 
         return ax
 
-    def scatter_projected_convex_hull(self, ax, **kwargs):
+    def scatter_projected_convex_hull(self, ax, kwargs={}):
         """Scatter the points of the convex hull, but project all points onto the composition
         space.
 
@@ -318,7 +318,7 @@ class Energy3(object):
         ax = scatter_projected_convex_hull(ax, self._running_data[self._xlabel],
                                         self._running_data[self._ylabel],
                                         self._running_data[self._zlabel],
-                                        **kwargs)
+                                        kwargs)
 
         ax.set_aspect('equal')
         return ax

--- a/thermoplotting/energy.py
+++ b/thermoplotting/energy.py
@@ -204,8 +204,10 @@ def hull_points(x, y, z):
     hull_points=[]
     for f in facets:
         for point in f:
-            hull_points.append(point)
-    hull_points=list(set(hull_points))
+            hull_points.append(tuple(point))
+    hull_points=set(hull_points)
+    for i,pt in enumerate(hull_points):
+        hull_points[i]=numpy.array(pt)
     return hull_points
 
 

--- a/thermoplotting/energy.py
+++ b/thermoplotting/energy.py
@@ -160,7 +160,7 @@ def draw_projected_convex_hull(ax,
 
     return ax
 
-def scatter_projected_convex_hull(ax, x, y, z, kwargs):
+def scatter_projected_convex_hull(ax, x, y, z, **kwargs):
     """Draw the points that make up the convex hull, but plot
     them projected onto the composition plane   
 
@@ -181,7 +181,7 @@ def scatter_projected_convex_hull(ax, x, y, z, kwargs):
     facets = ternary.pruned_hull_facets(digested)
 
     for f in facets:
-        ax = _scatter_projected_facet(ax, f, kwargs)
+        ax = _scatter_projected_facet(ax, f, **kwargs)
 
     #Set projected view? axis, aspect, etc?
     return ax
@@ -300,7 +300,7 @@ class Energy3(object):
 
         return ax
 
-    def scatter_projected_convex_hull(self, ax, kwargs={}):
+    def scatter_projected_convex_hull(self, ax, **kwargs):
         """Scatter the points of the convex hull, but project all points onto the composition
         space.
 
@@ -318,7 +318,7 @@ class Energy3(object):
         ax = scatter_projected_convex_hull(ax, self._running_data[self._xlabel],
                                         self._running_data[self._ylabel],
                                         self._running_data[self._zlabel],
-                                        kwargs)
+                                        **kwargs)
 
         ax.set_aspect('equal')
         return ax

--- a/thermoplotting/energy.py
+++ b/thermoplotting/energy.py
@@ -111,7 +111,7 @@ def _draw_projected_facet(ax, facet, kwargs):
     ax.add_patch(tri)
     return ax
 
-def _scatter_projected_facet(ax, facet, kwargs):
+def _scatter_projected_facet(ax, facet, **kwargs):
     """Scatter the corners of a facet onto the composition plane
 
     Parameters
@@ -160,7 +160,7 @@ def draw_projected_convex_hull(ax,
 
     return ax
 
-def scatter_projected_convex_hull(ax, x, y, z, kwargs):
+def scatter_projected_convex_hull(ax, x, y, z, **kwargs):
     """Draw the points that make up the convex hull, but plot
     them projected onto the composition plane   
 
@@ -181,7 +181,7 @@ def scatter_projected_convex_hull(ax, x, y, z, kwargs):
     facets = ternary.pruned_hull_facets(digested)
 
     for f in facets:
-        ax = _scatter_projected_facet(ax, f, kwargs)
+        ax = _scatter_projected_facet(ax, f, **kwargs)
 
     #Set projected view? axis, aspect, etc?
     return ax
@@ -300,7 +300,7 @@ class Energy3(object):
 
         return ax
 
-    def scatter_projected_convex_hull(self, ax, kwargs={}):
+    def scatter_projected_convex_hull(self, ax, **kwargs):
         """Scatter the points of the convex hull, but project all points onto the composition
         space.
 
@@ -318,7 +318,7 @@ class Energy3(object):
         ax = scatter_projected_convex_hull(ax, self._running_data[self._xlabel],
                                         self._running_data[self._ylabel],
                                         self._running_data[self._zlabel],
-                                        kwargs)
+                                        **kwargs)
 
         ax.set_aspect('equal')
         return ax


### PR DESCRIPTION
The function signatures suggested certain kwargs for matplotlib were being passed around. This was not done everywhere correctly. I've also added a hull points function to Energy3 to return the coordinates of the points of the all the hull facets as a set.